### PR TITLE
removes event listener to avert memleaks

### DIFF
--- a/js/main/module.js
+++ b/js/main/module.js
@@ -39,6 +39,12 @@ const inputEventHandler = (input) => {
 	if (file) {
 		reader.readAsText(file);
 	}
+
+	reader.removeEventListener(
+		"load",
+		() => loadEventHandler(),
+		false
+	);
 };
 
 const cancelEventHandler = () => {


### PR DESCRIPTION
NOTE:
This issue was brought to my attention by this article: https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener